### PR TITLE
Added logo and small nav change

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@cd/*": ["./src/customer_dashboard/*"]
     }
   },
   "exclude": ["node_modules", "dist"]

--- a/src/customer_dashboard/components/Navbar.vue
+++ b/src/customer_dashboard/components/Navbar.vue
@@ -2,14 +2,12 @@
   <header v-if="authStore.isAuthenticated" class="sticky top-0 z-50 border-b bg-card">
     <div class="container flex h-14 items-center justify-between">
       <RouterLink to="/store" class="flex items-center gap-2 text-lg font-bold text-primary">
-        <img src="https://placehold.co/32?text=MH" alt="Metro Hardware Logo" class="h-8 w-8 rounded-md" />
-        Metro Hardware
+        <div class="logo">
+          <img src="/metro-removebg-preview.png" style="width:160px; height:auto; object-fit:contain; display:block; margin-top:-30px; margin-bottom:-30px;"/>
+        </div>
       </RouterLink>
 
       <div class="flex items-center gap-2">
-        <span class="hidden text-sm text-muted-foreground sm:inline">
-          Welcome back, <strong class="text-foreground">{{ authStore.user?.name }}</strong>
-        </span>
 
         <Button variant="ghost" size="sm" as-child>
           <RouterLink to="/store/orders">


### PR DESCRIPTION
This pull request introduces improvements to the `customer_dashboard` module by updating module path aliases for better import management and enhancing the branding in the navigation bar. The most significant changes are grouped below:

**Project Structure and Module Resolution:**

* Added a new path alias `@cd/*` in `jsconfig.json` to point to the `src/customer_dashboard/*` directory, making imports from the customer dashboard more concise and maintainable.

**UI/Branding Enhancements:**

* Updated the logo in the `Navbar.vue` component to use a local image (`/metro-removebg-preview.png`) with custom styling, replacing the previous placeholder image and text for improved branding.