### PR TITLE
Fixed Order status in customer portal

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -5,6 +5,9 @@ from app import db
 from app.auth import AuthError, auth_required, issue_token, register_customer, serialize_user
 from app.models.user import User
 
+import yaml
+from flask import Response
+
 auth_ns = Namespace("auth", description="Authentication endpoints")
 
 login_model = auth_ns.model(
@@ -115,3 +118,11 @@ class MeResource(Resource):
         from app.auth import get_current_user
 
         return {"user": serialize_user(get_current_user())}, 200
+
+@auth_ns.route('/swagger.yaml')
+@auth_ns.hide
+class SwaggerYaml(Resource):
+    def get(self):
+        # Convert schema to YAML string
+        yaml_data = yaml.dump(api.__schema__, default_flow_style=False)
+        return Response(yaml_data, mimetype='text/yaml')

--- a/backend/app/api/customer_portal/customer_portal.py
+++ b/backend/app/api/customer_portal/customer_portal.py
@@ -284,11 +284,29 @@ class CustomerOrderDetailResource(Resource):
             sku_id = item["sku"]["skuId"]
             item["deliveredQty"] = total_delivered_by_sku.get(sku_id, 0)
             
+        # Compute dynamic order status
+        all_fulfilled = True
+        any_delivered = False
+        
+        for item in items:
+            if item["deliveredQty"] > 0:
+                any_delivered = True
+            if item["deliveredQty"] < item["orderedQty"]:
+                all_fulfilled = False
+                
+        if any_delivered:
+            if all_fulfilled:
+                computed_status = "Fulfilled"
+            else:
+                computed_status = "Partially Fulfilled"
+        else:
+            computed_status = "Order Confirmed"
+            
         return {
             "order": {
                 "coId": order.coid,
                 "orderDate": order.order_date.isoformat() if order.order_date else "",
-                "status": order.status or "Unknown"
+                "status": computed_status
             },
             "totalAmount": float(order.total_amount) if order.total_amount else 0.0,
             "invoices": invoice_list,

--- a/frontend/src/customer_dashboard/pages/TransactionDetails.vue
+++ b/frontend/src/customer_dashboard/pages/TransactionDetails.vue
@@ -8,15 +8,13 @@
     <div v-else-if="!orderData" class="container py-10 text-center text-muted-foreground">Order not found.</div>
 
     <template v-else>
-      <h1 class="mb-1 text-2xl font-bold text-foreground">Order #{{ orderData.order.coId }}</h1>
+      <div class="flex items-center justify-between mb-1">
+        <h1 class="text-2xl font-bold text-foreground">Order #{{ orderData.order.coId }}</h1>
+        <Badge :variant="orderData.order.status === 'Fulfilled' ? 'default' : (orderData.order.status === 'Partially Fulfilled' ? 'secondary' : 'outline')">
+          {{ orderData.order.status }}
+        </Badge>
+      </div>
       <p class="mb-6 text-sm text-muted-foreground">Placed on {{ orderData.order.orderDate }}</p>
-
-      <Card class="mb-6">
-        <CardHeader><CardTitle class="text-[21.6px]">Order Timeline</CardTitle></CardHeader>
-        <CardContent>
-          <OrderTimeline :status="orderData.order.status" :orderDate="orderData.order.orderDate" />
-        </CardContent>
-      </Card>
 
       <Card class="mb-6">
         <CardHeader><CardTitle>Items</CardTitle></CardHeader>
@@ -82,7 +80,7 @@ import CardContent from '@cd/components/ui/CardContent.vue'
 import CardHeader from '@cd/components/ui/CardHeader.vue'
 import CardTitle from '@cd/components/ui/CardTitle.vue'
 import Badge from '@cd/components/ui/Badge.vue'
-import OrderTimeline from '@cd/components/OrderTimeline.vue'
+
 import { FileText } from 'lucide-vue-next'
 
 const route = useRoute()


### PR DESCRIPTION
Order Status timeline removed from customer storefront in order-wise view. It is now replaced with a simple status. Status timeline is available only in item-wise view now