### PR TITLE
Updated test cases

### DIFF
--- a/backend/tests/test_inventory_api.py
+++ b/backend/tests/test_inventory_api.py
@@ -8,16 +8,21 @@ from app.models.user import User
 from app.models.vendor import Vendor, VendorProduct
 
 
+def _create_admin(uid="USR-ADMIN01", email="owner@metrohardware.com"):
+    admin = User(
+        uid=uid,
+        full_name="Metro Business Owner",
+        email=email,
+        role=User.ROLE_ADMIN,
+        is_active=True,
+    )
+    admin.set_password("password123")
+    return admin
+
+
 def test_inventory_overview_returns_joined_parts_and_statuses(client, app):
     with app.app_context():
-        admin = User(
-            uid="USR-ADMIN01",
-            full_name="Metro Business Owner",
-            email="owner@metrohardware.com",
-            role=User.ROLE_ADMIN,
-            is_active=True,
-        )
-        admin.set_password("password123")
+        admin = _create_admin()
         db.session.add(admin)
 
         vendor = Vendor(
@@ -122,14 +127,7 @@ def test_inventory_overview_requires_admin_role(client, app):
 
 def test_inventory_portfolio_keeps_distinct_full_spec_combinations(client, app):
     with app.app_context():
-        admin = User(
-            uid="USR-ADMIN02",
-            full_name="Metro Business Owner",
-            email="owner2@metrohardware.com",
-            role=User.ROLE_ADMIN,
-            is_active=True,
-        )
-        admin.set_password("password123")
+        admin = _create_admin(uid="USR-ADMIN02", email="owner2@metrohardware.com")
         db.session.add(admin)
 
         vendor = Vendor(
@@ -186,3 +184,257 @@ def test_inventory_portfolio_keeps_distinct_full_spec_combinations(client, app):
         '12mm x 45 mm\n1.5" · 58 to 62 mm',
         '12mm x 45 mm\n2" · 70 to 74 mm',
     ]
+
+
+def test_inventory_part_creation_persists_product_vendor_links_and_skus(client, app):
+    with app.app_context():
+        admin = _create_admin()
+        vendor_one = Vendor(vid="1", vendor_name="Amul Engineering", vendor_prefix="AE")
+        vendor_two = Vendor(vid="2", vendor_name="Khedut Enterprises", vendor_prefix="KE")
+        db.session.add_all([admin, vendor_one, vendor_two])
+        db.session.commit()
+        token = issue_token(admin)
+
+    response = client.post(
+        "/api/inventory/parts",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "name": "Borcap",
+            "category": "Pipe Fittings",
+            "vendorIds": ["1", "2"],
+            "unitMeasurementBuy": 6,
+            "lotSizeBuy": 3,
+            "specs": [
+                {
+                    "label": "12mm x 45 mm",
+                    "stockQty": 24,
+                    "threshold": 5,
+                    "sellPrice": "64.50",
+                    "vendorPrices": [
+                        {"vendorId": "1", "unitBuyPrice": "42.00"},
+                        {"vendorId": "2", "unitBuyPrice": "40.50"},
+                    ],
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.get_json()["product"]
+    assert payload == {
+        "id": "1",
+        "name": "Borcap",
+        "category": "Pipe Fittings",
+        "image": None,
+        "vendorIds": ["1", "2"],
+        "specCount": 1,
+    }
+
+    with app.app_context():
+        product = Product.query.filter_by(pid="1").first()
+        assert product is not None
+        assert product.pname == "Borcap"
+        assert product.category == "Pipe Fittings"
+
+        vendor_products = VendorProduct.query.filter_by(pid="1").order_by(VendorProduct.vid.asc()).all()
+        assert [vendor_product.vid for vendor_product in vendor_products] == ["1", "2"]
+
+        sku_one = (
+            db.session.query(SKU)
+            .join(VendorProduct, VendorProduct.vpid == SKU.vpid)
+            .filter(VendorProduct.pid == "1", VendorProduct.vid == "1")
+            .one()
+        )
+        sku_two = (
+            db.session.query(SKU)
+            .join(VendorProduct, VendorProduct.vpid == SKU.vpid)
+            .filter(VendorProduct.pid == "1", VendorProduct.vid == "2")
+            .one()
+        )
+
+        assert sku_one.unit_measurement_buy == 6
+        assert sku_one.lot_size_buy == 3
+        assert sku_one.current_buy_rate == Decimal("42.00")
+        assert sku_one.current_sell_rate == Decimal("64.50")
+        assert sku_one.stock_qty == 24
+        assert sku_one.threshold == 5
+        assert sku_one.specs == {"spec1": "12mm x 45 mm"}
+
+        assert sku_two.unit_measurement_buy == 6
+        assert sku_two.lot_size_buy == 3
+        assert sku_two.current_buy_rate == Decimal("40.50")
+        assert sku_two.current_sell_rate is None
+        assert sku_two.stock_qty == 0
+        assert sku_two.threshold == 0
+        assert sku_two.specs == {"spec1": "12mm x 45 mm"}
+
+
+def test_inventory_part_creation_requires_product_name(client, app):
+    with app.app_context():
+        admin = _create_admin()
+        vendor = Vendor(vid="1", vendor_name="Amul Engineering", vendor_prefix="AE")
+        db.session.add_all([admin, vendor])
+        db.session.commit()
+        token = issue_token(admin)
+
+    response = client.post(
+        "/api/inventory/parts",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "name": "   ",
+            "category": "Pipe Fittings",
+            "vendorIds": ["1"],
+            "unitMeasurementBuy": 6,
+            "lotSizeBuy": 3,
+            "specs": [
+                {
+                    "label": "12mm x 45 mm",
+                    "stockQty": 24,
+                    "threshold": 5,
+                    "sellPrice": "64.50",
+                    "vendorPrices": [{"vendorId": "1", "unitBuyPrice": "42.00"}],
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Product name is required."
+
+
+def test_inventory_part_creation_requires_at_least_one_vendor(client, app):
+    with app.app_context():
+        admin = _create_admin()
+        db.session.add(admin)
+        db.session.commit()
+        token = issue_token(admin)
+
+    response = client.post(
+        "/api/inventory/parts",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "name": "Borcap",
+            "category": "Pipe Fittings",
+            "vendorIds": [],
+            "unitMeasurementBuy": 6,
+            "lotSizeBuy": 3,
+            "specs": [
+                {
+                    "label": "12mm x 45 mm",
+                    "stockQty": 24,
+                    "threshold": 5,
+                    "sellPrice": "64.50",
+                    "vendorPrices": [],
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Select at least one vendor so the new specifications can be stored."
+
+
+def test_inventory_part_creation_rejects_duplicate_specifications(client, app):
+    with app.app_context():
+        admin = _create_admin()
+        vendor = Vendor(vid="1", vendor_name="Amul Engineering", vendor_prefix="AE")
+        db.session.add_all([admin, vendor])
+        db.session.commit()
+        token = issue_token(admin)
+
+    response = client.post(
+        "/api/inventory/parts",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "name": "Borcap",
+            "category": "Pipe Fittings",
+            "vendorIds": ["1"],
+            "unitMeasurementBuy": 6,
+            "lotSizeBuy": 3,
+            "specs": [
+                {
+                    "label": "12mm x 45 mm",
+                    "stockQty": 24,
+                    "threshold": 5,
+                    "sellPrice": "64.50",
+                    "vendorPrices": [{"vendorId": "1", "unitBuyPrice": "42.00"}],
+                },
+                {
+                    "label": "12mm x 45 mm",
+                    "stockQty": 12,
+                    "threshold": 3,
+                    "sellPrice": "61.00",
+                    "vendorPrices": [{"vendorId": "1", "unitBuyPrice": "40.00"}],
+                },
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Duplicate specification found: 12mm x 45 mm."
+
+
+def test_inventory_part_creation_requires_vendor_prices_for_all_selected_vendors(client, app):
+    with app.app_context():
+        admin = _create_admin()
+        vendor_one = Vendor(vid="1", vendor_name="Amul Engineering", vendor_prefix="AE")
+        vendor_two = Vendor(vid="2", vendor_name="Khedut Enterprises", vendor_prefix="KE")
+        db.session.add_all([admin, vendor_one, vendor_two])
+        db.session.commit()
+        token = issue_token(admin)
+
+    response = client.post(
+        "/api/inventory/parts",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "name": "Borcap",
+            "category": "Pipe Fittings",
+            "vendorIds": ["1", "2"],
+            "unitMeasurementBuy": 6,
+            "lotSizeBuy": 3,
+            "specs": [
+                {
+                    "label": "12mm x 45 mm",
+                    "stockQty": 24,
+                    "threshold": 5,
+                    "sellPrice": "64.50",
+                    "vendorPrices": [{"vendorId": "1", "unitBuyPrice": "42.00"}],
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Enter unit buy prices for every selected vendor for 12mm x 45 mm."
+
+
+def test_inventory_part_creation_rejects_unknown_vendor_selection(client, app):
+    with app.app_context():
+        admin = _create_admin()
+        db.session.add(admin)
+        db.session.commit()
+        token = issue_token(admin)
+
+    response = client.post(
+        "/api/inventory/parts",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "name": "Borcap",
+            "category": "Pipe Fittings",
+            "vendorIds": ["999"],
+            "unitMeasurementBuy": 6,
+            "lotSizeBuy": 3,
+            "specs": [
+                {
+                    "label": "12mm x 45 mm",
+                    "stockQty": 24,
+                    "threshold": 5,
+                    "sellPrice": "64.50",
+                    "vendorPrices": [{"vendorId": "999", "unitBuyPrice": "42.00"}],
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Unknown vendor selection: 999."

--- a/backend/tests/test_vendors_api.py
+++ b/backend/tests/test_vendors_api.py
@@ -628,6 +628,149 @@ def test_vendor_creation_rejects_invalid_phone_numbers(client, app):
     assert response.get_json()["message"] == "Phone number must be 10 digits. +91 in front is okay."
 
 
+def test_vendor_creation_requires_name(client, app):
+    with app.app_context():
+        admin = _create_admin()
+        db.session.add(admin)
+        db.session.commit()
+        token = issue_token(admin)
+
+    response = client.post(
+        "/api/vendors",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "name": "   ",
+            "phone": "9876543210",
+            "email": "missing-name@example.com",
+            "address": "Rajkot",
+            "leadTime": 3,
+            "productIds": [],
+            "prices": [],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Vendor name is required."
+
+
+def test_vendor_creation_rejects_negative_lead_time(client, app):
+    with app.app_context():
+        admin = _create_admin()
+        db.session.add(admin)
+        db.session.commit()
+        token = issue_token(admin)
+
+    response = client.post(
+        "/api/vendors",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "name": "Negative Lead Vendor",
+            "phone": "9876543210",
+            "email": "negative@example.com",
+            "address": "Rajkot",
+            "leadTime": -1,
+            "productIds": [],
+            "prices": [],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Lead time cannot be negative."
+
+
+def test_vendor_creation_rejects_unknown_selected_products(client, app):
+    with app.app_context():
+        admin = _create_admin()
+        db.session.add(admin)
+        db.session.commit()
+        token = issue_token(admin)
+
+    response = client.post(
+        "/api/vendors",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "name": "Unknown Product Vendor",
+            "phone": "9876543210",
+            "email": "unknown-product@example.com",
+            "address": "Rajkot",
+            "leadTime": 3,
+            "productIds": ["999"],
+            "prices": [],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Unknown product selection: 999."
+
+
+def test_vendor_creation_rejects_price_entries_for_unknown_products(client, app):
+    with app.app_context():
+        admin = _create_admin()
+        db.session.add(admin)
+        db.session.add(Product(pid="10", pname="Borcap", category="Petrol Engine"))
+        db.session.commit()
+        token = issue_token(admin)
+
+    response = client.post(
+        "/api/vendors",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "name": "Mismatched Price Vendor",
+            "phone": "9876543210",
+            "email": "mismatch@example.com",
+            "address": "Rajkot",
+            "leadTime": 4,
+            "productIds": ["10"],
+            "prices": [
+                {
+                    "productId": "404",
+                    "specs": {"spec1": "12mm x 45 mm"},
+                    "price": "22.00",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Unknown product in price list: 404."
+
+
+def test_vendor_creation_accepts_plus_91_phone_and_deduplicates_products(client, app):
+    with app.app_context():
+        admin = _create_admin()
+        db.session.add(admin)
+        product = Product(pid="10", pname="Borcap", category="Petrol Engine")
+        db.session.add(product)
+        db.session.commit()
+        token = issue_token(admin)
+
+    response = client.post(
+        "/api/vendors",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "name": "Shree Vendor House",
+            "phone": "+91 9876543210",
+            "email": "shree@example.com",
+            "address": "Rajkot",
+            "leadTime": 2,
+            "productIds": ["10", "10", "10"],
+            "prices": [],
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.get_json()["vendor"]
+    assert payload["prefix"] == "SVH"
+    assert payload["contact"]["phone"] == "+91 9876543210"
+    assert payload["parts"] == ["Borcap"]
+    assert payload["partCount"] == 1
+
+    with app.app_context():
+        vendor = Vendor.query.filter_by(vendor_name="Shree Vendor House").first()
+        assert vendor is not None
+        assert VendorProduct.query.filter_by(vid=vendor.vid, pid="10").count() == 1
+
+
 def test_vendor_delete_removes_vendor_products_and_skus_when_no_procurement_history(client, app):
     with app.app_context():
         admin = _create_admin()


### PR DESCRIPTION
This pull request adds comprehensive validation and persistence tests for the inventory and vendor creation APIs. It introduces new tests to ensure that product and vendor creation endpoints correctly handle required fields, reject invalid or inconsistent input, and persist relationships as expected. Additionally, a helper function is introduced to reduce duplication in admin user creation across tests.

**Inventory part creation tests:**

* Added tests to verify that creating a part persists product-vendor links and SKUs, and that the API enforces required fields (such as product name and at least one vendor), rejects duplicate specifications, requires vendor prices for all selected vendors, and rejects unknown vendor selections (`backend/tests/test_inventory_api.py`).

**Vendor creation validation tests:**

* Added tests to ensure vendor creation requires a name, rejects negative lead times, rejects unknown selected products, and rejects price entries for unknown products (`backend/tests/test_vendors_api.py`).
* Added a test to verify that vendor creation accepts phone numbers with a "+91" prefix and deduplicates product associations (`backend/tests/test_vendors_api.py`).

**Test code refactoring:**

* Introduced a `_create_admin` helper function to reduce code duplication when creating admin users in tests, and refactored existing tests to use this helper (`backend/tests/test_inventory_api.py`). [[1]](diffhunk://#diff-5068cf50642289f729502b6bb96fc971685809f51ee03e6f1a862b4c73a4c068L11-R25) [[2]](diffhunk://#diff-5068cf50642289f729502b6bb96fc971685809f51ee03e6f1a862b4c73a4c068L125-R130)